### PR TITLE
.Net Standard 2.0 target framework.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,19 @@
 
 This project is an extension of the [C# Zeebe client project](https://github.com/camunda-community-hub/zeebe-client-csharp). Zeebe Job handlers are automaticly recognized and bootstrapped via a [.Net HostedService](https://docs.microsoft.com/en-us/dotnet/architecture/microservices/multi-container-microservice-net-applications/background-tasks-with-ihostedservice).
 
+Read the [Zeebe documentation](https://docs.camunda.io/docs/components/zeebe/zeebe-overview/) for more information about the Zeebe project.
+
 ## Requirements
 
-* .Net 6.0
+* net standard 2.0 or higher, which means
+    * .net core 2.1 or higher
+    * or .net framework 4.7.1 or higher
 * latest [C# Zeebe client release](https://www.nuget.org/packages/zb-client/)
 * latest [Zeebe release](https://github.com/zeebe-io/zeebe/releases/)
 
 ## How to use
 
-The Zeebe C# client bootstrap extensions is available via nuget (https://www.nuget.org/packages/zb-client-bootstrap/).
+The Zeebe C# client bootstrap extension is available via nuget (https://www.nuget.org/packages/zb-client-bootstrap/).
 
 See [examples] and [blog post](https://link.medium.com/4a3yax14gjb) for more information.
 

--- a/src/Zeebe.Client.Bootstrap/Options/ZeebeClientBootstrapOptions.cs
+++ b/src/Zeebe.Client.Bootstrap/Options/ZeebeClientBootstrapOptions.cs
@@ -13,7 +13,7 @@ namespace Zeebe.Client.Bootstrap.Options
             public virtual string GatewayAddress { get; set; }
             public virtual TransportEncryptionOptions TransportEncryption { get; set; }        
             public virtual long? KeepAliveInMilliSeconds { get; set; }
-            public virtual TimeSpan? KeepAlive { get { return KeepAliveInMilliSeconds.HasValue ? TimeSpan.FromMilliseconds(KeepAliveInMilliSeconds.Value) : null; } }
+            public virtual TimeSpan? KeepAlive { get { return KeepAliveInMilliSeconds.HasValue ? TimeSpan.FromMilliseconds(KeepAliveInMilliSeconds.Value) : (TimeSpan?) null; } }
             public virtual Func<int, TimeSpan> RetrySleepDurationProvider { get; set; }
 
             public class TransportEncryptionOptions 

--- a/src/Zeebe.Client.Bootstrap/Zeebe.Client.Bootstrap.csproj
+++ b/src/Zeebe.Client.Bootstrap/Zeebe.Client.Bootstrap.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Arjan Geertsema</Authors>
     <Description>
 This project is an extension of the zb-client (https://www.nuget.org/packages/zb-client/). 


### PR DESCRIPTION
Changed target framework to .net standard 2.0 so that the library can be used in older .net framework versions.