### PR TITLE
Possible to use token with custom certificate

### DIFF
--- a/src/Zeebe.Client.Bootstrap/Extensions/ZeebeClientBuilderExtensions.cs
+++ b/src/Zeebe.Client.Bootstrap/Extensions/ZeebeClientBuilderExtensions.cs
@@ -27,16 +27,18 @@ namespace Zeebe.Client.Bootstrap.Extensions
             if(options.TransportEncryption == null)
                 return builder.UsePlainText();
 
-            if(!String.IsNullOrEmpty(options.TransportEncryption.RootCertificatePath))
-                return builder.UseTransportEncryption(options.TransportEncryption.RootCertificatePath);
+            IZeebeSecureClientBuilder clientBuilder = null;
+            if (!String.IsNullOrEmpty(options.TransportEncryption.RootCertificatePath))
+                clientBuilder = builder.UseTransportEncryption(options.TransportEncryption.RootCertificatePath);
+            else
+                clientBuilder = builder.UseTransportEncryption();
 
             if(!string.IsNullOrEmpty(options.TransportEncryption.AccessToken))
-                return builder.UseTransportEncryption().UseAccessToken(options.TransportEncryption.AccessToken);
+                clientBuilder.UseAccessToken(options.TransportEncryption.AccessToken);
+            else if(options.TransportEncryption.AccessTokenSupplier != null)
+                clientBuilder.UseAccessTokenSupplier(options.TransportEncryption.AccessTokenSupplier);
 
-            if(options.TransportEncryption.AccessTokenSupplier != null)
-                return builder.UseTransportEncryption().UseAccessTokenSupplier(options.TransportEncryption.AccessTokenSupplier);
-
-            throw new NotImplementedException($"{nameof(options.TransportEncryption)} is instantiated but none of it's properties have valid values.");
+            return clientBuilder;
         }
 
         private static IZeebeClient BuildClient(this IZeebeClientFinalBuildStep builder, ClientOptions options)


### PR DESCRIPTION
Right now we expect only one of RootCertificatePath, AccessToken and AccessTokenSupplier to be present.
It should be possible to provide a root certificate and use "access token" or "access token supplier" at the same time.

If the TransportEncryption block it present but is empty, we will default to builder.UseTransportEncryption()